### PR TITLE
Disable widgets depending on creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recogito-client-core",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Core functions, classes and components for RecogitoJS",
   "main": "src/index.js",
   "sideEffects": [

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -9,8 +9,9 @@ import equals from 'fast-deep-equal';
  */
 export default class Selection {
 
-  constructor(target, body) {
+  constructor(creator, target, body) {
     this.underlying = {
+      creator,
       type: 'Selection',
       body: body || [],
       target
@@ -31,6 +32,10 @@ export default class Selection {
 
   get type() {
     return this.underlying.type;
+  }
+
+  get creator() {
+    return this.underlying.creator;
   }
 
   get body() {

--- a/src/WebAnnotation.js
+++ b/src/WebAnnotation.js
@@ -55,6 +55,10 @@ export default class WebAnnotation {
     return this.underlying.type;
   }
 
+  get creator() {
+    return this.underlying.creator;
+  }
+
   get motivation() {
     return this.underlying.motivation;
   }

--- a/src/editor/Editor.jsx
+++ b/src/editor/Editor.jsx
@@ -299,12 +299,11 @@ export default class Editor extends Component {
       this.props.widgets.map(getWidget) : DEFAULT_WIDGETS;
 
     const isReadOnlyWidget = w => {
-      const {underlying} = currentAnnotation
-      if (!underlying.creator?.id) {
+      if (!currentAnnotation.creator?.id) {
         // Disable the widget if there isn't a creator with an id
         w.props.disabled = true
         return true
-      } else if (underlying.creator.id !== this.props.config.user.id) {
+      } else if (currentAnnotation.creator.id !== this.props.config.user.id) {
         // Disable the widget if the creator is different than the user
         w.props.disabled = true
         return true

--- a/src/editor/Editor.jsx
+++ b/src/editor/Editor.jsx
@@ -298,20 +298,27 @@ export default class Editor extends Component {
     const widgets = this.props.widgets ? 
       this.props.widgets.map(getWidget) : DEFAULT_WIDGETS;
 
-    const isReadOnlyWidget = w => w.type.disableDelete ?
-      w.type.disableDelete(currentAnnotation, {
-        ...w.props,
-        readOnly:this.props.readOnly,
-        env: this.props.env,
-        editable: this.props.config.editable
-      }) : false;
+    const isReadOnlyWidget = w => {
+      const {underlying} = currentAnnotation
+      if (!underlying.creator?.id) {
+        // Disable the widget if there isn't a creator with an id
+        w.props.disabled = true
+        return true
+      } else if (underlying.creator.id !== this.props.config.user.id) {
+        // Disable the widget if the creator is different than the user
+        w.props.disabled = true
+        return true
+      }
+      w.props.disabled = false
+      return false
+    };
 
     const hasDelete = currentAnnotation && 
       // annotation has bodies or allowEmpty,
       (currentAnnotation.bodies.length > 0 || this.props.allowEmpty) && // AND
       !this.props.readOnly && // we are not in read-only mode AND
       !currentAnnotation.isSelection && // this is not a selection AND
-      !widgets.some(isReadOnlyWidget);  // every widget is deletable
+      !widgets.map(isReadOnlyWidget).some(isReadOnly => isReadOnly === true);  // every widget is deletable
 
     return (
       <Draggable 

--- a/src/editor/widgets/comment/CommentWidget.jsx
+++ b/src/editor/widgets/comment/CommentWidget.jsx
@@ -94,7 +94,7 @@ const CommentWidget = props => {
           key={idx} 
           env={props.env}
           purposeSelector={props.purposeSelector}
-          readOnly={isReadOnlyComment(body, props)} 
+          readOnly={props.disabled} 
           body={body} 
           onUpdate={props.onUpdateBody}
           onDelete={props.onRemoveBody}


### PR DESCRIPTION
This disables ALL widgets if the `annotation.underlying.creator` DNE or is different than the `config.user` when initializing recogito.