### PR TITLE
Allow multiple Select Widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recogito-client-core",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Core functions, classes and components for RecogitoJS",
   "main": "src/index.js",
   "sideEffects": [

--- a/src/editor/Editor.jsx
+++ b/src/editor/Editor.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Draggable from 'react-draggable';
 import { getWidget, DEFAULT_WIDGETS } from './widgets';
+import Label from './Label';
 import { TrashIcon } from '../Icons';
 import setPosition from './setPosition';
 import i18n from '../i18n';

--- a/src/editor/Editor.jsx
+++ b/src/editor/Editor.jsx
@@ -323,8 +323,11 @@ export default class Editor extends Component {
         <div ref={this.element} className={this.state.dragged ? 'r6o-editor dragged' : 'r6o-editor'}>
           <div className="r6o-arrow" />
           <div className="r6o-editor-inner">
-            {widgets.map((widget, idx) => 
-              React.cloneElement(widget, { 
+          {widgets.map((widget, idx) =>
+            <div className="widget">
+              {widget.props.config?.inputLabel && 
+                <Label labelName={widget.props.config.inputLabel}/>}
+              {React.cloneElement(widget, { 
                 ...this.props.config,
                 key: `widget-${idx}`,
                 focus: idx === 0,
@@ -338,36 +341,36 @@ export default class Editor extends Component {
                 onBatchModify: this.onBatchModify,
                 onSetProperty: this.onSetProperty,
                 onSaveAndClose: this.onOk
-              })
-            )}
-            
-            { this.props.readOnly ? (
-              <div className="r6o-footer">
-                <button
-                  className="r6o-btn" 
-                  onClick={this.onCancel}>{i18n.t('Close')}</button>
-              </div>
-            ) : (
-              <div 
-                className={this.props.detachable ? "r6o-footer r6o-draggable" : "r6o-footer"}>
-                { hasDelete && (
-                  <button 
-                    className="r6o-btn left delete-annotation" 
-                    title={i18n.t('Delete')}
-                    onClick={this.onDelete}>
-                    <TrashIcon width={12} />
-                  </button>
-                )}
-
+              })}
+            </div>
+          )}
+          { this.props.readOnly ? (
+            <div className="r6o-footer">
+              <button
+                className="r6o-btn" 
+                onClick={this.onCancel}>{i18n.t('Close')}</button>
+            </div>
+          ) : (
+            <div 
+              className={this.props.detachable ? "r6o-footer r6o-draggable" : "r6o-footer"}>
+              { hasDelete && (
                 <button 
-                  className="r6o-btn outline"
-                  onClick={this.onCancel}>{i18n.t('Cancel')}</button>
+                  className="r6o-btn left delete-annotation" 
+                  title={i18n.t('Delete')}
+                  onClick={this.onDelete}>
+                  <TrashIcon width={12} />
+                </button>
+              )}
 
-                <button 
-                  className="r6o-btn "
-                  onClick={this.onOk}>{i18n.t('Ok')}</button>
-              </div>
-            )}
+              <button 
+                className="r6o-btn outline"
+                onClick={this.onCancel}>{i18n.t('Cancel')}</button>
+
+              <button 
+                className="r6o-btn "
+                onClick={this.onOk}>{i18n.t('Ok')}</button>
+            </div>
+          )}
           </div>
         </div>
 

--- a/src/editor/Label.jsx
+++ b/src/editor/Label.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Label = props => {
+  return (
+    <label className='input-label'>
+      {props.labelName}
+    </label>
+  )
+}
+
+export default Label

--- a/src/editor/widgets/index.jsx
+++ b/src/editor/widgets/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CommentWidget from './comment/CommentWidget'
+import SelectWidget from './select/SelectWidget';
 import TagWidget from './tag/TagWidget';
 import WrappedWidget from './WrappedWidget';
 
@@ -15,7 +16,8 @@ window.ReactDOM = ReactDOM;
 /** Standard widgets included by default **/
 const BUILTIN_WIDGETS = {
   COMMENT: CommentWidget,
-  TAG: TagWidget
+  TAG: TagWidget,
+  SELECT: SelectWidget
 };
 
 /** Defaults to use if there's no overrides from the host app **/

--- a/src/editor/widgets/select/SelectWidget.jsx
+++ b/src/editor/widgets/select/SelectWidget.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Select from 'react-select';
-import Label from '../../Label';
 
 const CLASSIFYING = 'classifying'
 

--- a/src/editor/widgets/select/SelectWidget.jsx
+++ b/src/editor/widgets/select/SelectWidget.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import Select from 'react-select';
+import Label from '../../Label';
+
+const CLASSIFYING = 'classifying'
+
+const baseSelectOption = args => ({
+  type: 'OptionSelection', value: '', purpose: CLASSIFYING, ...args
+})
+
+const SelectWidget = props => {
+  // Use the context to determine which option to delete in the annotation.bodies
+  // since we're using multiple SelectWidgets
+  const {disabled, annotation, config} = props
+  const {options, context} = config
+  let {placeholder} = config
+
+  const selectedOption = !annotation ? null : 
+    annotation.bodies.find(b => b.purpose === CLASSIFYING && b.context === context);
+
+  const onChange = option => {
+    if (!option && selectedOption) {
+      props.onRemoveBody(selectedOption)
+    } else if (option) {
+      const {value} = option
+      const updatedOption = baseSelectOption({value, context});
+      if (selectedOption) {
+        props.onUpdateBody(selectedOption, updatedOption)
+      } else {
+        props.onAppendBody(updatedOption);
+      }
+    }
+  }
+
+  let selectedOptionValue = null;
+  if (selectedOption) {
+    selectedOptionValue = options.find(({value}) => value === selectedOption.value)
+  }
+  // Change the placeholder if there isn't an option and it's disabled
+  if (!selectedOptionValue && disabled) {
+    placeholder = 'None'
+  }
+  return (
+      <Select
+        value={selectedOptionValue}
+        onChange={onChange}
+        options={options}
+        placeholder={placeholder}
+        isDisabled={disabled}
+        isClearable
+      />
+  )
+
+}
+
+export default SelectWidget;

--- a/themes/default/editor/_label.scss
+++ b/themes/default/editor/_label.scss
@@ -1,0 +1,6 @@
+.input-label {
+  font-size: 12px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/themes/default/theme.scss
+++ b/themes/default/theme.scss
@@ -1,5 +1,6 @@
 @import "globals/globals";
 @import "editor/editor";
+@import "editor/label";
 
 .r6o-noselect {
   -webkit-touch-callout:none;


### PR DESCRIPTION
JIRA Key: https://pathlighthq.atlassian.net/browse/FUJ-2124

In order to use it, you'll need to set the config into `new Recogito()` like so:
```JS
{
    content: subcontentElement,
    editorAutoPosition: true,
    mode: 'pre',
    user: {id: currentUser.id, name: currentUser.name, photo_url: currentUser.photo_url},
    widgets: [
        {widget: 'COMMENT', config: {inputLabel: "Comment:"}},
        {widget: 'SELECT', config: {
            options: [
                {label: 'first', value: '1'},
                {label: 'second', value: '2'},
            ], 
            placeholder: 'Select a category...',
            context: 'category',
            inputLabel: 'Category (optional):'
        }},
        {widget: 'SELECT', config: {
            options: [
                {label: 'third', value: '3rd'},
                {label: 'fourth', value: '4th'},
            ], 
            placeholder: 'Select a question...', 
            context: 'question',
            inputLabel: 'Question (optional):'
        }}
    ]
}
```

![image](https://user-images.githubusercontent.com/33470093/172477081-44da94bd-63ab-47b2-aaee-8d5a31ba0f58.png)

The styling of the editor will be changed in subsequent PRs.